### PR TITLE
Modifica tamaño de botón jugar

### DIFF
--- a/index.css
+++ b/index.css
@@ -38,6 +38,8 @@ header{
     text-align: start;
 }
 .boton-jugar{
+    width: 176px;
+    height: 26px;
     background-color: var(--colores-interfaz-beige);
     border-top: 2px solid #a39481;
     border-left: 2px solid #a39481;


### PR DESCRIPTION
Cambia el tamaño del botón jugar agrandándolo para que no se modifique por su cuenta al indicar el turno del juego, ya que al cambiar el contenido del texto, este no cabía.