### PR TITLE
Modifica tiempos de espera de la máquina

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function gestionarPrimeraRonda(){
 }
 
 function gestionarActualizacionesDeRonda(){
-    const retrasoEnMilisegundos = listaSecuenciaMaquina.length * 2200;
+    const retrasoEnMilisegundos = listaSecuenciaMaquina.length * 1000;
     setTimeout(function(){
         actualizarNumeroDeRonda();
         imprimirNumeroDeRonda();
@@ -81,7 +81,7 @@ function gestionarActualizacionesDeRonda(){
 }
 
 function gestionarActualizacionesTurno(){
-    const retrasoEnMilisegundos = listaSecuenciaMaquina.length * 2200;
+    const retrasoEnMilisegundos = listaSecuenciaMaquina.length * 1000;
     setTimeout(function(){
         actualizarTurnos();
         imprimirIndicadorTurno();


### PR DESCRIPTION
Los tiempos de espera anteriores iban aumentando a medida que la secuencia de la máquina aumentaban, dejando un delay de actualización en los avisos de turnos y rondas.