### PR TITLE
Crea funciones para gestionar colores del usuario

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,43 @@ function imprimirIndicadorTurno(){
     }
 }
 
+function desactivarColoresParaUsuario(){
+    const botonesColoresTablero = document.querySelectorAll (".colores-tablero");
+
+    if(indicadorDeTurno === "maquina"){
+        for(let i = 0; i < botonesColoresTablero.length; i++){
+            botonesColoresTablero[i].disabled = true;
+        }
+    }
+    else if(juegoComenzado === false){
+        for(let i = 0; i < botonesColoresTablero.length; i++){
+            botonesColoresTablero[i].disabled = true;
+        }
+    }
+    else if(indicadorDeTurno === "usuario"){
+        return false;
+    }
+    else{
+        return false;
+    }
+}
+
+function activarColoresParaUsuario(){
+    const botonesColoresTablero = document.querySelectorAll (".colores-tablero");
+
+    if(indicadorDeTurno === "maquina"){
+        return false;
+    }
+    else if(indicadorDeTurno === "usuario"){
+        for(let i = 0; i < botonesColoresTablero.length; i++){
+            botonesColoresTablero[i].disabled = false;
+        }
+    }
+    else{
+        return false;
+    }
+}
+
 function gestionarPrimeraRonda(){
     actualizarNumeroDeRonda();
     imprimirNumeroDeRonda();
@@ -89,6 +126,13 @@ function gestionarActualizacionesTurno(){
     setTimeout(function(){
         actualizarTurnos();
         imprimirIndicadorTurno();
+    }, retrasoEnMilisegundos)
+}
+
+function gestionarActivacionDeColoresUsuario(){
+    const retrasoEnMilisegundos = listaSecuenciaMaquina.length * 1000;
+    setTimeout(function(){
+        activarColoresParaUsuario();
     }, retrasoEnMilisegundos)
 }
 


### PR DESCRIPTION
Se crean 3 funciones, una para desactivar los colores del usuario cuando la máquina esté jugando. Otro para activar los colores del usuario cuando sea su turno, y por último la función para gestionar los tiempos de espera para llamar a la función que activa los colores, para que se activen cuando la máquina termine su turno.